### PR TITLE
docs: initiate documentation

### DIFF
--- a/docs/architecture/AI_MEMORY.md
+++ b/docs/architecture/AI_MEMORY.md
@@ -1,0 +1,28 @@
+# AI Service & Memory
+
+The AI Service allows AURA to read, comprehend, and recall large chunks of data across different formats utilizing **Retrieval-Augmented Generation (RAG)**.
+
+## Framework
+The AI Service runs on Python `FastAPI`, providing standardized REST routes for knowledge processing.
+
+## The Memory Pipeline
+
+When a user uploads a document through the AURA Dashboard (e.g. `guide.pdf`):
+1. **Ingestion**: The document is sent via `POST /api/v1/memory`.
+2. **Chunking**: The document text is extracted (via PDF parser) and split into smaller, overlapping chunks (e.g. 500 characters per chunk).
+3. **Embedding**: A local `Sentence-Transformers` model evaluates the context of the chunk and translates it into a dense mathematical vector.
+4. **Storage**: The vector, alongside the original text and metadata, is saved in the **Supabase** instance using the `pgvector` extension.
+
+> [!NOTE]  
+> Historical iteration note: Older documentation and comments might reference *Qdrant* as a vector DB. The codebase currently exclusively utilizes Supabase `pgvector` for both Conversation standard memory and RAG embeddings to unify dependencies.
+
+## Semantic Search During Conversation
+
+When a user speaks:
+1. The `voice-agent` retrieves the transcribed user text.
+2. Submits the text query to `POST /api/v1/chat` inside the AI Service.
+3. The AI Service runs semantic similarity search on Supabase, comparing the user's prompt against all saved document vectors.
+4. Retrieves the top matching text chunks.
+5. Injects the text chunks seamlessly into the System Prompt context before contacting the LLM.
+
+As a result, AURA dynamically has context as if she "remembered" reading the document.

--- a/docs/architecture/AVATAR_SYSTEM.md
+++ b/docs/architecture/AVATAR_SYSTEM.md
@@ -1,0 +1,39 @@
+# Avatar System Architecture
+
+AURA renders its avatar purely in the browser, alleviating the need for users to configure external tools like VTube Studio. This reduces latency, lowers system overhead, and dramatically simplifies deployment.
+
+## Core Technologies
+
+- **[pixi.js v6](https://pixijs.com/)**: Serves as the core WebGL engine and canvas renderer.
+- **[pixi-live2d-display (0.4)](https://github.com/guansss/pixi-live2d-display)**: A specialized PIXI.js extension that allows native ingestion and drawing of Cubism models.
+- **Cubism 4 Web SDK (WASM)**: The underlying core runtime engine that interprets Live2D parametric models.
+
+> [!WARNING]  
+> AURA's frontend utilizes `pixi.js v6`, because `pixi-live2d-display v0.4` does not support `pixi.js v7+`. Upgrading `pixi.js` via NPM will break the Avatar renderer entirely. Ensure dependencies remain locked in the Dashboard's `package.json`.
+
+## How it works: End-to-end Rendering
+
+1. **Initialization**:  
+   The React `AvatarRenderer.jsx` script creates a PIXI Application bound to a `<canvas>` element filling the screen.
+
+2. **Model Loading**:  
+   Via `Live2DModel.from(URL)`, the model loads all associated assets (masks, textures, `.exp3.json` expressions, physics files) directly using browser network requests.
+
+3. **Injected Animation Loop**:  
+   Rather than relying upon standard `.motion3.json` playback exclusively, AURA monkey-patches the `coreModel.update()` function from PIXI. Every frame, right before vertex data is committed to the GPU, AURA updates logic:
+   - **Blink FSM (Finite State Machine)**: Evaluates random timers to trigger organic eye blinks.
+   - **Eye Saccades**: Adds micro-randomization to `ParamEyeBallX` and `ParamEyeBallY`.
+   - **Sway & Breath**: Uses `Math.sin()` multiplied by epoch time to calculate organic breathing cycles mapped to `ParamBreath` and `ParamBodyAngleZ`.
+
+## Lip Sync Pipeline
+
+Since the Voice Pipeline streams synthesized speech audio chunks over a LiveKit WebRTC channel, AURA captures this stream using the Web Audio API.
+
+1. Takes the `MediaStreamTrack` from LiveKit.
+2. Mounts an `AnalyserNode` to compute the Root Mean Square (RMS) amplitude of audio bytes.
+3. In a `requestAnimationFrame` loop, RMS maps directly to the Cubism parameter `ParamMouthOpenY` (from 0 to 1). This delivers 100% synchronized, framerate-independent lip movements without complex phoneme extraction.
+
+## Expression Triggering
+
+The Voice Agent passes an "Emotion Tag" over a LiveKit data channel message (e.g., `["shadow", "pupil_shrink"]`).
+The frontend maps these tags to corresponding Live2D Expression names, using the `setExpression` native calls to smoothly interpolate parameter changes visually.

--- a/docs/architecture/VOICE_PIPELINE.md
+++ b/docs/architecture/VOICE_PIPELINE.md
@@ -1,0 +1,39 @@
+# Voice Pipeline Architecture
+
+The Voice Pipeline orchestrates the critical pathway enabling users to speak to AURA and receive ultra-fast verbal responses with corresponding emotion tags. This entire workflow resides in the Python `voice-agent` application.
+
+## The Workflow Map
+
+```mermaid
+sequenceDiagram
+    participant U as User Mic
+    participant LK as LiveKit Cloud
+    participant STT as Deepgram STT
+    participant LLM as OpenRouter
+    participant TTS as Qwen3-TTS GPU
+    participant UI as Dashboard
+
+    U->>LK: raw audio track
+    LK->>STT: pipe stream
+    STT-->>LK: Transcript (e.g., "Hello")
+    LK->>LLM: Prompt + Conversation History
+    LLM-->>LK: " [happy] Hello there!"
+    LK->>TTS: Submits sentence string
+    TTS-->>LK: Raw synthesized audio buffer
+    LK->>UI: WebRTC Audio playback
+    LK->>UI: JSON Data Channel ["happy"]
+```
+
+## Component Breakdowns
+
+### Speech-to-Text (Deepgram)
+Deepgram's Nova-3 tier allows the `voice-agent` to interpret speech with sub-300ms latency. Because it is highly capable in multiple languages, the user does not need to declare which language they are speaking beforehand. 
+
+### Local TTS Engine (Faster-Qwen3-TTS)
+While Cloud TTS services (like ElevenLabs) offer fantastic voices, they suffer from internet backhaul latency and price constraints. AURA operates **Faster-Qwen3-TTS** entirely locally on GPU.
+- **Why Fast?**: A 12 Hz codec and serialized CUDA calls ensure minimal buffer stalling.
+- **Budget Control**: The generator computes `max_new_tokens` dynamically based on the string length of the LLM output. This aggressive cut-off prevents "hallucination loops" where the TTS outputs ambient static or endless silence at the end of generations.
+- **Silence Trimming**: The internal `_trim_silence()` parses 25ms audio chunks backward, aggressively discarding dead trailing silence to ensure AURA immediately finishes her turn perfectly in sync with the end of her sentence.
+
+### The Livekit Agent Toolkit
+The `voice-agent` is built upon the `livekit-agents` v1.3 library. It inherently supplies Silero VAD (Voice Activity Detection), meaning it intelligently knows when a user is speaking, when they pause, and if they interrupt AURA. If the user interrupts, the Python token stream and TTS generator are halted, immediately silencing the character.

--- a/docs/developer/AI_SERVICE.md
+++ b/docs/developer/AI_SERVICE.md
@@ -1,0 +1,32 @@
+# AI Service Developer Guide
+
+The AI Service handles the memory ingestion logic for AURA's "Brain," dealing with RAG (Retrieval-Augmented Generation) architectures. 
+
+## Python Ecosystem
+This service is substantially lighter than the `voice-agent` and does not formally require PyTorch GPU dependencies locally, allowing standard Venv utilization.
+
+```bash
+cd ai-service
+python -m venv venv
+source venv/bin/activate  # macOS/Linux
+# venv\Scripts\activate   # Windows
+pip install -r requirements.txt
+uvicorn app.main:app --reload
+```
+
+## Exploring API Endpoints
+FastAPI natively builds fully interactive OpenAPI documentation interfaces.
+Rather than attempting to trigger memory ingestion strictly through the React UI, you can test payloads quickly during backend hacking directly from the browser natively.
+
+1. Ensure `uvicorn` is running.
+2. Open your browser and navigate to `http://localhost:8000/docs`.
+3. You can execute `POST /api/v1/memory` uploads directly from this page, feeding fake test PDFs into the vector engine.
+
+## Resetting Supabase Memory locally
+If you wish to purge the memory instance, since we leverage the Supabase `pgvector` container extension:
+1. Connect via CLI or Datagrip to your Supabase project URL credentials referenced in `.env`.
+2. Truncate the `memories` table:
+   ```sql
+   TRUNCATE TABLE memories;
+   ```
+3. This deletes all semantic vectors and chunks. Re-upload documents to test clean indices.

--- a/docs/developer/API_REFERENCE.md
+++ b/docs/developer/API_REFERENCE.md
@@ -1,0 +1,38 @@
+# API Reference
+
+The AURA Backend provides multiple HTTP/REST endpoints for programmatic interaction, operated via FastAPI on the `ai-service` and the lightweight auth `token-server`.
+
+## AI Service Endpoints 
+**Base URL**: `http://localhost:8000`
+
+### `POST /api/v1/chat`
+- **Description**: Primary interface for triggering a textual RAG query into the Supabase Memory database without invoking the Voice Agent.
+- **Request Body**:
+  ```json
+  {
+    "message": "What is the primary theme of the uploaded PDF?",
+    "user_id": "optional-uuid"
+  }
+  ```
+- **Response**: String containing the prompt + the RAG contextual chunks.
+
+### `POST /api/v1/memory` (Document Ingestion)
+- **Description**: Uploads a document to chunk and embed into the vector database.
+- **Content-Type**: `multipart/form-data`
+- **Parameters**: 
+  - `file`: The `.txt`, `.pdf`, or `.pptx` file payload.
+- **Response**: `200 OK` on successful parse and Supabase insertion.
+
+---
+
+## Token Server Endpoints
+**Base URL**: `http://localhost:8082`
+
+### `GET /getToken`
+- **Description**: Requested by the frontend `livekit-client` upon instantiation to authorize access to the LiveKit Cloud websocket.
+- **Response**:
+  ```json
+  {
+    "token": "eyJhbGci..."
+  }
+  ```

--- a/docs/developer/CONTRIBUTING.md
+++ b/docs/developer/CONTRIBUTING.md
@@ -23,7 +23,10 @@ Branches must be named clearly and consistently corresponding to their component
 ---
 
 ## 💻 Local Development
-For detailed local setup instructions, component architecture, and API documentation, please visit our documentation website or view the markdown files located in `docs/developer/`.
+If you are planning to hack on AURA, please review the local setup guides for each decoupled module:
+- [Frontend Dashboard Guide](FRONTEND.md)
+- [Python Voice Agent Guide](VOICE_AGENT.md)
+- [FastAPI AI Service Guide](AI_SERVICE.md)
 
 ---
 

--- a/docs/developer/CUSTOMIZATION.md
+++ b/docs/developer/CUSTOMIZATION.md
@@ -1,0 +1,35 @@
+# Customization & Tweaking
+
+AURA is highly modular, allowing developers to adapt its aesthetics, models, and personality.
+
+## 1. Modifying the Live2D Avatar
+
+The default model is Hu Tao mapping a `.model3.json` file. You can swap this with any valid Cubism 4 model.
+
+1. Locate a Live2D Cubism 4 Model folder containing:
+   - `<ModelName>.model3.json`
+   - `.moc3` binary
+   - Contains textures in `.png`
+   - Physics `.json`
+   - `.exp3.json` expression files
+2. Create a folder inside the Dashboard public directory: `dashboard/public/models/<ModelName>`
+3. Copy the files into the new directory.
+4. Modify `MODEL_URL` inside `dashboard/src/components/AvatarRenderer.jsx` to point to the new JSON file:
+   ```javascript
+   const MODEL_URL = "/models/<ModelName>/<ModelName>.model3.json";
+   ```
+
+### Overriding Expressions
+Different modellers use different IDs for expressions. By default, the `voice-agent` outputs names like `smile` and `shadow`. If your new character uses `Exp_Happy.exp3.json`, you must modify the `voice-agent/avatar_bridge.py` mapping dict so that python string outputs correctly bind to the new Model's `.exp3.json` file names.
+
+## 2. Modifying Voice Characteristics
+AURA's local GPU TTS is generated using Faster-Qwen3-TTS.
+
+To change the generation parameters (Speed, Hallucination cut-offs):
+- Open `voice-agent/aura_tts.py`
+- Modify `repetition_penalty` (Increase if AURA keeps repeating words).
+- Modify the multiplier for `max_new_tokens` depending on if you switch to a more loquacious LLM.
+
+## 3. Adapting the Personality Prompt
+The instructions fed to the OpenRouter LLM controlling AURA are defined in the backend codebase (and eventually via the `personality_settings` in Supabase). 
+To make AURA speak differently, add specific instructions to the System Prompts ensuring she consistently returns `[emotion_tag]` pre-fixes, or the visual avatar will stall out while the voice speaks.

--- a/docs/developer/FRONTEND.md
+++ b/docs/developer/FRONTEND.md
@@ -1,0 +1,30 @@
+# Frontend Hacking Guide
+
+The AURA Dashboard handles LiveKit WebRTC state management and directly renders the Pixi.js avatar on an HTML5 Canvas.
+
+## Tech Stack
+- **Framework:** React 19 + Vite
+- **Styling:** Tailwind CSS V4
+- **WebGL Rendering:** Pixi.js v6 + `pixi-live2d-display`
+
+## Running the Development Server
+Since UI changes require instant visual feedback, you should run the Vite dev server manually instead of relying on the overarching containerized solution.
+
+1. Keep your AI Service and Voice Agent running in the background.
+2. In a new terminal tab, navigate to the dashboard map.
+   ```bash
+   cd dashboard
+   npm install --no-fund
+   npm run dev
+   ```
+3. Open `http://localhost:5173`. Any changes to React `.jsx` components will instantly Hot-Module-Reload (HMR) without needing a page refresh.
+
+## Modifying the Avatar
+
+### Dependency Warning
+> [!WARNING]
+> Do **not** upgrade `pixi.js` via NPM. The currently locked mechanism uses `pixi.js` v6 because `pixi-live2d-display` is deeply broken on Pixi versions 7 and 8 due to Cubism WASM breaking changes.
+
+### Adding New Idle Animations
+If you wish to make the character blink differently or sway faster, locate `src/components/AvatarRenderer.jsx` and inspect the injected `coreModel.update()` patch.
+This block intercepts the Live2D GPU memory pipeline. You can inject native JS `Math.sin()` loops to map custom procedural animations before the frame is rendered!

--- a/docs/developer/INDEX.md
+++ b/docs/developer/INDEX.md
@@ -1,0 +1,23 @@
+# Component Directory
+
+A high level map of the repository structure to help navigate where code lives.
+
+```text
+project-aura/
+├── dashboard/               # React 19 frontend
+│   ├── src/components/      # AvatarRenderer, CallOverlay (lip sync logic)
+│   └── public/              # Served assets, Cubism WASM runtime, Live2D Models
+│
+├── voice-agent/             # Python LiveKit WebRTC Worker
+│   ├── agent.py             # Main entry point for the process
+│   ├── aura_tts.py          # Faster-Qwen3-TTS generation parameters
+│   └── avatar_bridge.py     # Parses text tags into WebRTC data channel events
+│
+├── ai-service/              # FastAPI Memory & RAG provider
+│   ├── app/main.py          # REST endpoints
+│   └── app/services/        # Ingestion logic, Chunking, Embedding
+│
+├── docs/                    # The documentation you are reading now
+├── start_aura.bat           # Desktop bootloader for Windows
+└── docker-compose.yml       # Production docker bootloader
+```

--- a/docs/developer/VOICE_AGENT.md
+++ b/docs/developer/VOICE_AGENT.md
@@ -1,0 +1,44 @@
+# Voice Agent Developer Guide
+
+The `voice-agent` orchestrates the WebRTC connection, transcription, Large Language Model context injection, and fast local TTS synthesis.
+
+## Environment Architecture
+
+Because this relies extensively on heavy Python C-bindings (PyTorch, Numpy), we utilize `conda` to prevent package collision and linker issues across Apple Silicon and Windows environments securely.
+
+### Quick Start
+1. Ensure Miniconda is installed.
+2. Inside the root of the project, generate the environment map:
+   ```bash
+   cd voice-agent
+   conda env create -f environment.yml
+   ```
+   *(macOS users should use `environment-macos.yml`)*
+3. Activate the fresh environment:
+   ```bash
+   conda activate aura
+   ```
+4. Start the script independently:
+   ```bash
+   python agent.py dev
+   ```
+
+## Running Automated Tests
+
+When contributing PRs that touch the WebRTC socket logic or the Text-to-Speech logic, you **must** validate your changes against the Pytest harness.
+
+We have a robust mocked framework located in `voice-agent/tests/`.
+
+To execute:
+```bash
+cd voice-agent
+conda activate aura
+pip install pytest pytest-asyncio
+pytest tests/
+```
+Ensure all tests evaluate to green before committing. 
+
+## Editing the TTS
+We use a wrapper around `Faster-Qwen3-TTS` located inside `aura_tts.py`.
+Most parameter modifications (such as voice speed, pitch modulations, or strict memory pruning logic) will happen here. 
+If you encounter memory leaks during synthesis generation, ensure you haven't dropped the `_gen_lock` thread-state which forces generation to be strictly synchronous on the GPU vector.

--- a/docs/getting-started/CONFIGURATION.md
+++ b/docs/getting-started/CONFIGURATION.md
@@ -1,0 +1,37 @@
+# Configuration
+
+AURA relies on several cloud services and APIs to function, specifically for WebRTC (LiveKit), STT (Deepgram), LLMs (OpenRouter), and Memory (Supabase).
+
+You must copy `.env.example` to `.env` in the root of the `project-aura` folder before launching the application.
+
+## Core Services
+
+### Voice and Video Signal (LiveKit)
+LiveKit handles WebRTC streams, connecting the Dashboard to the Python Voice Agent.
+- `LIVEKIT_URL`: Web Socket URL of your LiveKit instance (e.g., `wss://aura-xyz.livekit.cloud`).
+- `LIVEKIT_API_KEY`: The API key from your LiveKit dashboard.
+- `LIVEKIT_API_SECRET`: The API secret from your LiveKit dashboard.
+
+### Speech-to-Text (Deepgram)
+AURA uses Deepgram's Nova-3 model for incredibly fast, multilingual transcription.
+- `DEEPGRAM_API_KEY`: Create an account at [Deepgram](https://deepgram.com/) and generate an API key.
+
+### LLM Inference (OpenRouter)
+OpenRouter provides unified access to LLMs. By default, AURA relies on `DeepSeek-V3` for conversational intelligence.
+- `OPENROUTER_API_KEY`: Create an account at [OpenRouter](https://openrouter.ai/) to generate a key.
+
+### Semantic Memory and History (Supabase)
+Used by the AI Service to store vector embeddings for the RAG pipeline.
+- `SUPABASE_URL`: The URL of your Supabase project (e.g., `https://xyz.supabase.co`).
+- `SUPABASE_KEY`: The `anon` or `service_role` key from Supabase API settings.
+
+---
+
+## Optional Toggles
+
+### Legacy VTube Studio Integration
+- `VTUBE_ENABLED`: Set to `"true"` **only if** you intend to bypass the browser-based Live2D renderer and inject expressions directly into the standalone VTube Studio application.
+  - *Default: `"false"`*
+
+### Additional Settings
+Depending on your LLM latency and network bandwidth, you may find additional performance flags in the `voice-agent`'s `.env`, though standard deployments generally only require the configuration mentioned above.

--- a/docs/getting-started/INSTALLATION.md
+++ b/docs/getting-started/INSTALLATION.md
@@ -1,0 +1,71 @@
+# Installation Guide
+
+Project AURA can be installed primarily on **Windows** using the native launcher, or via **Docker** for containerized deployments.
+
+## Prerequisites
+
+Regardless of how you install AURA, you need:
+- **API Keys**: See [Configuration](CONFIGURATION.md) for a list of necessary API keys.
+- **Microphone and Speakers**: For voice interaction.
+
+---
+
+## 1. Native Installation (Windows / macOS)
+
+This is the recommended installation method as it avoids Docker container abstraction, making it easier to debug the voice pipelines and GPU acceleration.
+
+### System Requirements
+- **Python**: `3.10` to `3.12` (Python `3.13+` is currently unsupported by some dependencies).
+- **Node.js**: The latest LTS release.
+- **Miniconda**: For streamlined Python virtual environment setup.
+- **Git**: To clone the repository.
+- **NVIDIA GPU** (Optional but recommended): Required to run the local `Faster-Qwen3-TTS` engine at lightning-fast speeds.
+
+### Steps
+
+1. **Clone the repository**
+   ```bash
+   git clone https://github.com/ASE-Lab/project-aura.git
+   cd project-aura
+   ```
+
+2. **Configure `.env`**
+   Copy `.env.example` to `.env` and fill in the required API keys. [View Configuration Details](CONFIGURATION.md).
+
+3. **Start the Application**
+   For Windows:
+   ```powershell
+   ./start_aura.bat
+   ```
+   For macOS / Unix:
+   ```bash
+   ./start_aura.sh
+   ```
+
+   _Note: The first run may take 5–10 minutes to download necessary machine-learning models (~2 GB total). Subsequent runs will be significantly faster._
+
+4. **Access the Dashboard**
+   Once all services confirm they are running, open **[http://localhost:5173](http://localhost:5173)** in your browser. The Live2D avatar will load automatically.
+
+---
+
+## 2. Docker Installation
+
+For those who want a completely isolated deployment.
+
+### System Requirements
+- **Docker Desktop**
+- **NVIDIA Container Toolkit**: If you're on Windows/Linux and want to expose your GPU to the container for TTS performance.
+
+### Steps
+
+1. **Clone & Configure**
+   Same as Steps 1 & 2 above. Ensure your `.env` is fully populated.
+
+2. **Run Docker Compose**
+   ```bash
+   docker compose up --build
+   ```
+
+3. **Access the Dashboard**
+   Once Docker has spun up all containers (Dashboard, Voice Agent, AI Service, Token Server), open **[http://localhost:5173](http://localhost:5173)** in your browser.

--- a/docs/getting-started/USAGE.md
+++ b/docs/getting-started/USAGE.md
@@ -1,0 +1,34 @@
+# Usage Guide
+
+Once you have successfully launched AURA and opened **[http://localhost:5173](http://localhost:5173)**, you will be greeted by the Dashboard.
+
+## 1. Connecting to the Agent
+- Ensure your microphone is functional and not blocked by the browser.
+- Click **"Connect"** or the microphone icon on the Dashboard.
+- Say a greeting like "Hello, AURA." The LiveKit indicator should show that your user stream is transmitting, and AURA will reply natively.
+
+## 2. Using the Knowledge Base (RAG)
+One of AURA's core features is the semantic memory provided by the AI-Service and Supabase.
+
+### Uploading Documents
+- Locate the document upload section on the dashboard UI.
+- You can upload `.txt`, `.pdf`, or `.pptx` files.
+- Once uploaded, the `AI Service` automatically unzips, chunks, embeds the texts, and stores them in your Supabase `pgvector` store.
+
+### Asking Contextual Questions
+- Simply ask AURA via voice about the document.
+- Example: *"AURA, based on the PDF I just uploaded, what is the main objective of the Q3 project?"*
+- AURA will process the prompt, fetch relevant vector matches from Supabase, and synthesize a response that is then piped out through the local TTS.
+
+## 3. Bilingual Mode
+Because Deepgram Nova-3 and the local Qwen3-TTS engine support multilingual capabilities across English and Japanese, you can transparently change languages mid-sentence, and AURA's LLM will match the primary language in its contextual response.
+
+## Troubleshooting Common Issues
+
+### Avatar isn't moving its mouth
+- Ensure the `AnalyserNode` logic in the Dashboard component is receiving an audio stream. Check your browser console via `F12` to ensure `livekit-client` successfully connected to the WebRTC server.
+- The lip sync relies entirely on RMS audio amplitude mapped to `ParamMouthOpenY`.
+
+### "Agent Offline" or Disconnected
+- Make sure all microservices are running. If `start_aura.bat` was killed, or Docker containers crashed, the Voice Agent Python app might not be polling LiveKit.
+- Check the console logs of the `Voice Agent` window.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,20 @@
+# Welcome to Project AURA
+
+AURA (Advanced Universal Responsive Avatar) is a seamless, local-first AI companion featuring a browser-rendered Live2D avatar, sub-500ms voice interactions, and semantic document memory (RAG).
+
+## Key Features
+
+1. **Ultra-Low Latency Voice Setup**
+   AURA leverages LiveKit WebRTC and local Faster-Qwen3-TTS running on your GPU to achieve sub-500ms conversational latencies. 
+2. **Browser-Native Live2D Avatar**
+   The avatar is fully browser-based, making use of `pixi-live2d-display` and Cubism 4 WASM. No VTube Studio or external rendering engines are required (though conditionally supported based on your preference).
+3. **Continuous Smart Memory**
+   Using FastAPI, Sentence-Transformers, and Supabase pgvector, users can upload PDFs and text documents which AURA semantically recalls and leverages during conversations.
+4. **Emotional Intelligence Engine**
+   AURA is prompted to dynamically respond with emotion tags, which are immediately translated into real-time visual Live2D expression parameters.
+
+## Where to go from here?
+
+- Read the **[Installation Guide](getting-started/INSTALLATION.md)** to run AURA locally.
+- Review **[Configuration](getting-started/CONFIGURATION.md)** to correctly set up your `.env` API keys.
+- Dive into the **[Avatar Architecture](architecture/AVATAR_SYSTEM.md)** to understand how the browser-based Live2D renderer works.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,10 @@ nav:
     - Voice Pipeline: "architecture/VOICE_PIPELINE.md"
     - Memory & RAG: "architecture/AI_MEMORY.md"
   - Developer Guide:
+    - Contribution Flow: "developer/CONTRIBUTING.md"
+    - Frontend Hacking: "developer/FRONTEND.md"
+    - Voice Agent Hacking: "developer/VOICE_AGENT.md"
+    - AI Service Hacking: "developer/AI_SERVICE.md"
     - Customization: "developer/CUSTOMIZATION.md"
     - API Reference: "developer/API_REFERENCE.md"
     - Component Map: "developer/INDEX.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,55 @@
+site_name: Project AURA
+site_description: Documentation for AURA - Advanced Universal Responsive Avatar
+theme:
+  name: material
+  palette:
+    # Palette toggle for true black/light mode
+    - scheme: default
+      primary: cyan
+      accent: deep purple
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: cyan
+      accent: deep purple
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - toc.integrate
+    - search.suggest
+
+nav:
+  - Welcome: "index.md"
+  - Getting Started:
+    - Installation: "getting-started/INSTALLATION.md"
+    - Configuration: "getting-started/CONFIGURATION.md"
+    - Usage: "getting-started/USAGE.md"
+  - Architecture:
+    - Avatar Setup: "architecture/AVATAR_SYSTEM.md"
+    - Voice Pipeline: "architecture/VOICE_PIPELINE.md"
+    - Memory & RAG: "architecture/AI_MEMORY.md"
+  - Developer Guide:
+    - Customization: "developer/CUSTOMIZATION.md"
+    - API Reference: "developer/API_REFERENCE.md"
+    - Component Map: "developer/INDEX.md"
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.tabbed:
+      alternate_style: true

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "docs": "mkdocs serve"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.95.3",


### PR DESCRIPTION
## Summary
initialize project documentation and structure with comprehensve setup, architecture, and customization guides

## Changes
- Add markdown documentation
- Add static page documentation based on markdown

## Testing
- Run `pip install mkdocs-material`
- Test with `npm run docs` then open `localhost:8000`
- @Raygama check if the docs is correct with the project aura context
